### PR TITLE
Add partial dCBOR item parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ It is intended for use in testing, debugging, the `dcbor` command line tool, and
 The primary functions provided are:
 
 - `parse_dcbor_item`: Parses a string in CBOR diagnostic notation into a `CBOR` object.
+- `parse_dcbor_item_partial`: Parses the first item in a string and reports how
+  many bytes were consumed.
 - `compose_dcbor_array`: Composes a `CBOR` array from a slice of strings representing dCBOR items in diagnostic notation.
 - `compose_dcbor_map`: Composes a `CBOR` map from a slice of strings representing the key-value pairs in dCBOR diagnostic notation.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 //! for examples of how to register your own tags.
 
 mod parse;
-pub use parse::parse_dcbor_item;
+pub use parse::{parse_dcbor_item, parse_dcbor_item_partial};
 
 mod token;
 pub use token::Token;
@@ -66,6 +66,5 @@ pub use error::{Error as ParseError, Result as ParseResult};
 
 mod compose;
 pub use compose::{
-    Error as ComposeError, Result as ComposeResult, compose_dcbor_array,
-    compose_dcbor_map,
+    Error as ComposeError, Result as ComposeResult, compose_dcbor_array, compose_dcbor_map,
 };

--- a/tests/test_parse.rs
+++ b/tests/test_parse.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use base64::Engine as _;
 use bc_ur::prelude::*;
-use dcbor_parse::{ParseError, parse_dcbor_item};
+use dcbor_parse::{ParseError, parse_dcbor_item, parse_dcbor_item_partial};
 use indoc::indoc;
 
 fn roundtrip<T: Into<CBOR>>(value: T) {
@@ -291,4 +291,19 @@ fn test_end_of_line_comments() {
     let src = "[1, 2, 3] # this should be ignored";
     let result = parse_dcbor_item(src).unwrap();
     assert_eq!(result, vec![1, 2, 3].into());
+}
+
+#[test]
+fn test_parse_partial_basic() {
+    let (cbor, used) = parse_dcbor_item_partial("true )").unwrap();
+    assert_eq!(cbor, CBOR::from(true));
+    assert_eq!(used, 5);
+}
+
+#[test]
+fn test_parse_partial_trailing_ws() {
+    let src = "false  # comment\n";
+    let (cbor, used) = parse_dcbor_item_partial(src).unwrap();
+    assert_eq!(cbor, CBOR::from(false));
+    assert_eq!(used, src.len());
 }


### PR DESCRIPTION
## Summary
- add `parse_dcbor_item_partial` function
- export new API and document in README
- test new parsing behavior

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68527b1dcfec83258b34920b56e5ed33